### PR TITLE
Bug Fix for F_ELTMONTHS

### DIFF
--- a/src/functions/F_ELTMONTHS.sql
+++ b/src/functions/F_ELTMONTHS.sql
@@ -20,13 +20,13 @@
 *  Example:                                                                                                            *
 *                                                                                                                      *
 *      SELECT *                                                                                                        *
-*      FROM F_ELTMONTHS(7, 2016);                                                                                      *
+*      FROM F_ELTMONTHS(2, 2017);                                                                                      *
 *                                                                                                                      *
 *                                                                                                                      *
 *      dtype | sdate      | edate                                                                                      *
-*      1     | 2016-07-01 | 2016-10-31                                                                                 *
-*      2     | 2016-10-01 | 2016-10-31                                                                                 *
-*      3     | 2015-10-01 | 2015-10-31                                                                                 *
+*      1     | 2016-07-01 | 2017-02-28                                                                                 *
+*      2     | 2017-02-01 | 2017-02-28                                                                                 *
+*      3     | 2016-02-01 | 2016-02-29                                                                                 *
 *                                                                                                                      *
 ***********************************************************************************************************************/
 
@@ -57,8 +57,17 @@ CREATE FUNCTION dbo.F_ELTMONTHS(@mnth TINYINT, @yr SMALLINT)
     -- Declares a variable used to define the third starting date
     DECLARE @sdate3 AS DATE;
 
+    -- Variable used to handle dates in the second half of the academic year
+    DECLARE @yroffset AS SMALLINT;
+
+    -- Offsets the academic year to get the correct value for the year to date year by subtracting 1
+    IF @mnth BETWEEN 1 AND 6 SET @yroffset = @yr - 1;
+
+    -- Otherwise uses the year passed by end user
+    ELSE SET @yroffset = @yr;
+
     -- Sets the value of the first starting date to the start of the fiscal year
-    SET @sdate1 = (SELECT CAST('07/01/' + CAST(@yr AS VARCHAR(4)) AS DATE));
+    SET @sdate1 = (SELECT CAST('07/01/' + CAST(@yroffset AS VARCHAR(4)) AS DATE));
 
     -- Sets the value of the second starting date to the first day of the provided month and year
     SET @sdate2 = (SELECT CAST(
@@ -94,3 +103,5 @@ CREATE FUNCTION dbo.F_ELTMONTHS(@mnth TINYINT, @yr SMALLINT)
 GO
 
 
+SELECT *
+FROM dbo.F_ELTMONTHS(2, 2017);

--- a/src/functions/F_GET_MAP.sql
+++ b/src/functions/F_GET_MAP.sql
@@ -1,8 +1,16 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+*  Name: F_GET_MAP                                                                                                     *
+*                                                                                                                      *
+*  Description: Function used to return NWEA MAP RIT Scores and Percentiles for Reading/Language Arts, Math, and       *
+*  language for one or all students for a given school year.                                                           *
+*                                                                                                                      *
+***********************************************************************************************************************/
 
 -- Checks if the function exists in the database
 IF object_id(N'dbo.F_GET_MAP', N'TF') IS NOT NULL
 
-	  -- Drops the function if it already exists
+  -- Drops the function if it already exists
   DROP FUNCTION dbo.F_GET_MAP;
 
 -- End of batch block
@@ -12,111 +20,102 @@ GO
 CREATE FUNCTION dbo.F_GET_MAP(@schyr SMALLINT, @persid INT = NULL)
 
   -- Defines the table that the function returns
-  RETURNS @retval TABLE (
-	        sasid VARCHAR(15) NOT NULL,
-		        pid INT,
-			        schyr INT NOT NULL,
-				        mapmthsc1 SMALLINT,
-					        mapmthpct1 TINYINT,
-						        maprlasc1 SMALLINT,
-							        maprlapct1 TINYINT,
-								        maplansc1 SMALLINT,
-									        maplanpct1 TINYINT,
-										        mapmthsc2 SMALLINT,
-											        mapmthpct2 TINYINT,
-												        maprlasc2 SMALLINT,
-													        maprlapct2 TINYINT,
-														        maplansc2 SMALLINT,
-															        maplanpct2 TINYINT,
-																        mapmthsc3 SMALLINT,
-																	        mapmthpct3 TINYINT,
-																		        maprlasc3 SMALLINT,
-																			        maprlapct3 TINYINT,
-																				        maplansc3 SMALLINT,
-																					        maplanpct3 TINYINT
-																						  ) AS
+  RETURNS @retval TABLE (pid INT PRIMARY KEY, schyr INT NOT NULL,
+    mapmthsc1 SMALLINT, mapmthpct1 TINYINT, maprlasc1 SMALLINT, maprlapct1 TINYINT,
+    maplansc1 SMALLINT, maplanpct1 TINYINT, mapmthsc2 SMALLINT, mapmthpct2 TINYINT,
+    maprlasc2 SMALLINT, maprlapct2 TINYINT, maplansc2 SMALLINT, maplanpct2 TINYINT,
+    mapmthsc3 SMALLINT, mapmthpct3 TINYINT, maprlasc3 SMALLINT, maprlapct3 TINYINT,
+    maplansc3 SMALLINT, maplanpct3 TINYINT) AS
 
-																						  -- Starts the function body
+  -- Starts the function body
   BEGIN
 
-	    -- Declares a table variable that holds the initial query from which the joins
-    -- are performed
-    DECLARE @students TABLE(sasid VARCHAR(15) NOT NULL,
-	                            pid INT,
-				                            schyr INT NOT NULL,
-							                            sc SMALLINT,
-										                            tid INT,
-													                            pct TINYINT,
-																                            period TINYINT);
-
-																		    -- If no personID is passed
+    -- If no personID is passed
     IF @persid IS NULL
 
-	      -- Get all of the data for a given year for all students in the table
-      INSERT @students (sasid, pid, schyr, sc, tid, pct, period)
-      SELECT DISTINCT p.stateID AS sasid,
-                      ts.personID AS pid,
-		                      @schyr AS schyr,
-				                      CAST(ts.scaleScore AS SMALLINT) AS sc,
-						                      ts.testID AS tid,
-								                      CAST(ts.percentile AS TINYINT) AS pct,
-										                      dbo.F_MAP_PERIODS(ts.date) AS period
-												      FROM            [fayette].[dbo].[TestScore] AS ts
-												      INNER JOIN      [fayette].[dbo].[person] p ON p.personID = ts.personID
-												      WHERE           ts.testID BETWEEN 1427 AND 1429 AND
-												                      dbo.F_ENDYEAR(ts.date, DEFAULT) = @schyr;
+      -- Use a common table expression to handle the correlated subqueries
+      WITH a AS ( SELECT DISTINCT   ts.personID AS pid,
+                                    CAST(ts.scaleScore AS SMALLINT) AS sc,
+                                    ts.testID AS tid,
+                                    CAST(ts.percentile AS TINYINT) AS pct,
+                                    dbo.F_MAP_PERIODS(ts.date) AS period
+                  FROM              [fayette].[dbo].[TestScore] AS ts
+                  WHERE             ts.testID BETWEEN 1427 AND 1429 AND
+                                    dbo.F_ENDYEAR(ts.date, DEFAULT) = @schyr)
 
-														    -- If a person ID is passed to the function
+      -- Put the data into the
+      INSERT @retval(pid, schyr,
+                    mapmthsc1, mapmthpct1, maprlasc1, maprlapct1, maplansc1, maplanpct1,
+                    mapmthsc2, mapmthpct2, maprlasc2, maprlapct2, maplansc2, maplanpct2,
+                    mapmthsc3, mapmthpct3, maprlasc3, maprlapct3, maplansc3, maplanpct3)
+      SELECT DISTINCT   a.pid, @schyr AS schyr,
+                        CASE WHEN b.period = 1 THEN b.sc END AS mapmthsc1,
+                        CASE WHEN b.period = 1 THEN b.pct END AS mapmthpct1,
+                        CASE WHEN c.period = 1 THEN c.sc END AS maprlasc1,
+                        CASE WHEN c.period = 1 THEN c.pct END AS maprlapct1,
+                        CASE WHEN d.period = 1 THEN d.sc END AS maplansc1,
+                        CASE WHEN d.period = 1 THEN d.pct END AS maplanpct1,
+                        CASE WHEN b.period = 2 THEN b.sc END AS mapmthsc2,
+                        CASE WHEN b.period = 2 THEN b.pct END AS mapmthpct2,
+                        CASE WHEN c.period = 2 THEN c.sc END AS maprlasc2,
+                        CASE WHEN c.period = 2 THEN c.pct END AS maprlapct2,
+                        CASE WHEN d.period = 2 THEN d.sc END AS maplansc2,
+                        CASE WHEN d.period = 2 THEN d.pct END AS maplanpct2,
+                        CASE WHEN b.period = 3 THEN b.sc END AS mapmthsc3,
+                        CASE WHEN b.period = 3 THEN b.pct END AS mapmthpct3,
+                        CASE WHEN c.period = 3 THEN c.sc END AS maprlasc3,
+                        CASE WHEN c.period = 3 THEN c.pct END AS maprlapct3,
+                        CASE WHEN d.period = 3 THEN d.sc END AS maplansc3,
+                        CASE WHEN d.period = 3 THEN d.pct END AS maplanpct3
+      FROM              a
+      LEFT JOIN         a AS b ON a.pid = b.pid AND b.tid = 1427
+      LEFT JOIN         a AS c ON a.pid = c.pid AND c.tid = 1428
+      LEFT JOIN         a AS d ON a.pid = d.pid AND d.tid = 1429
+
+
+    -- If a person ID is passed to the function
     ELSE
 
-	      -- Get the data for just that individual student
-      INSERT @students (sasid, pid, schyr, sc, tid, pct, period)
-      SELECT DISTINCT p.stateID AS sasid,
-                      ts.personID AS pid,
-		                      @schyr AS schyr,
-				                      CAST(ts.scaleScore AS SMALLINT) AS sc,
-						                      ts.testID AS tid,
-								                      CAST(ts.percentile AS TINYINT) AS pct,
-										                      dbo.F_MAP_PERIODS(ts.date) AS period
-												      FROM            [fayette].[dbo].[TestScore] AS ts
-												      INNER JOIN      [fayette].[dbo].[person] p ON p.personID = ts.personID
-												      WHERE           ts.testID BETWEEN 1427 AND 1429 AND
-												                      dbo.F_ENDYEAR(ts.date, DEFAULT) = @schyr AND
-														                      ts.personID = @persid;
+      -- Use a common table expression to handle the correlated subqueries
+      WITH a AS ( SELECT DISTINCT   ts.personID AS pid,
+                                    CAST(ts.scaleScore AS SMALLINT) AS sc,
+                                    ts.testID AS tid,
+                                    CAST(ts.percentile AS TINYINT) AS pct,
+                                    dbo.F_MAP_PERIODS(ts.date) AS period
+                  FROM              [fayette].[dbo].[TestScore] AS ts
+                  WHERE             ts.testID BETWEEN 1427 AND 1429 AND
+                                    dbo.F_ENDYEAR(ts.date, DEFAULT) = @schyr AND
+                                    ts.personID = @persid)
+      -- Put the data into the
+      INSERT @retval(pid, schyr,
+                    mapmthsc1, mapmthpct1, maprlasc1, maprlapct1, maplansc1, maplanpct1,
+                    mapmthsc2, mapmthpct2, maprlasc2, maprlapct2, maplansc2, maplanpct2,
+                    mapmthsc3, mapmthpct3, maprlasc3, maprlapct3, maplansc3, maplanpct3)
+      SELECT DISTINCT   a.pid, @schyr AS schyr,
+                        CASE WHEN b.period = 1 THEN b.sc END AS mapmthsc1,
+                        CASE WHEN b.period = 1 THEN b.pct END AS mapmthpct1,
+                        CASE WHEN c.period = 1 THEN c.sc END AS maprlasc1,
+                        CASE WHEN c.period = 1 THEN c.pct END AS maprlapct1,
+                        CASE WHEN d.period = 1 THEN d.sc END AS maplansc1,
+                        CASE WHEN d.period = 1 THEN d.pct END AS maplanpct1,
+                        CASE WHEN b.period = 2 THEN b.sc END AS mapmthsc2,
+                        CASE WHEN b.period = 2 THEN b.pct END AS mapmthpct2,
+                        CASE WHEN c.period = 2 THEN c.sc END AS maprlasc2,
+                        CASE WHEN c.period = 2 THEN c.pct END AS maprlapct2,
+                        CASE WHEN d.period = 2 THEN d.sc END AS maplansc2,
+                        CASE WHEN d.period = 2 THEN d.pct END AS maplanpct2,
+                        CASE WHEN b.period = 3 THEN b.sc END AS mapmthsc3,
+                        CASE WHEN b.period = 3 THEN b.pct END AS mapmthpct3,
+                        CASE WHEN c.period = 3 THEN c.sc END AS maprlasc3,
+                        CASE WHEN c.period = 3 THEN c.pct END AS maprlapct3,
+                        CASE WHEN d.period = 3 THEN d.sc END AS maplansc3,
+                        CASE WHEN d.period = 3 THEN d.pct END AS maplanpct3
+      FROM              a
+      LEFT JOIN         a AS b ON a.pid = b.pid AND b.tid = 1427
+      LEFT JOIN         a AS c ON a.pid = c.pid AND c.tid = 1428
+      LEFT JOIN         a AS d ON a.pid = d.pid AND d.tid = 1429;
 
-																    -- Put the data into the
-    INSERT @retval(sasid, pid, schyr,
-	                  mapmthsc1, mapmthpct1, maprlasc1, maprlapct1, maplansc1, maplanpct1,
-			                  mapmthsc2, mapmthpct2, maprlasc2, maprlapct2, maplansc2, maplanpct2,
-					                  mapmthsc3, mapmthpct3, maprlasc3, maprlapct3, maplansc3, maplanpct3)
-						    SELECT DISTINCT   a.sasid, a.pid, a.schyr,
-						                      CASE WHEN b.period = 1 THEN b.sc END AS mapmthsc1,
-									                      CASE WHEN b.period = 1 THEN b.pct END AS mapmthpct1,
-												                      CASE WHEN c.period = 1 THEN c.sc END AS maprlasc1,
-															                      CASE WHEN c.period = 1 THEN c.pct END AS maprlapct1,
-																		                      CASE WHEN d.period = 1 THEN d.sc END AS maplansc1,
-																					                      CASE WHEN d.period = 1 THEN d.pct END AS maplanpct1,
-																								                      CASE WHEN b.period = 2 THEN b.sc END AS mapmthsc2,
-																											                      CASE WHEN b.period = 2 THEN b.pct END AS mapmthpct2,
-																														                      CASE WHEN c.period = 2 THEN c.sc END AS maprlasc2,
-																																	                      CASE WHEN c.period = 2 THEN c.pct END AS maprlapct2,
-																																				                      CASE WHEN d.period = 2 THEN d.sc END AS maplansc2,
-																																							                      CASE WHEN d.period = 2 THEN d.pct END AS maplanpct2,
-																																										                      CASE WHEN b.period = 3 THEN b.sc END AS mapmthsc3,
-																																													                      CASE WHEN b.period = 3 THEN b.pct END AS mapmthpct3,
-																																																                      CASE WHEN c.period = 3 THEN c.sc END AS maprlasc3,
-																																																			                      CASE WHEN c.period = 3 THEN c.pct END AS maprlapct3,
-																																																						                      CASE WHEN d.period = 3 THEN d.sc END AS maplansc3,
-																																																									                      CASE WHEN d.period = 3 THEN d.pct END AS maplanpct3
-																																																												    FROM @students AS a
-																																																												    LEFT JOIN @students AS b ON a.sasid = b.sasid AND a.pid = b.pid AND
-																																																												                                a.schyr = b.schyr AND b.tid = 1427
-																																																																    LEFT JOIN @students AS c ON a.sasid = c.sasid AND a.pid = c.pid AND
-																																																																                                a.schyr = c.schyr AND c.tid = 1428
-																																																																				    LEFT JOIN @students AS d ON a.sasid = d.sasid AND a.pid = d.pid AND
-																																																																				                                a.schyr = d.schyr AND d.tid = 1429
-
-																																																																								  -- Returns the table valued return object
+  -- Returns the table valued return object
   RETURN;
 
   -- End of the function body
@@ -125,8 +124,10 @@ CREATE FUNCTION dbo.F_GET_MAP(@schyr SMALLINT, @persid INT = NULL)
 -- End of the batch statement
 GO
 
--- Use example
+-- Example of using the function to retrieve all records for the 2016-2017 school year
 SELECT *
-FROM dbo.F_GET_MAP(2017, 10);
+FROM FCPS_BB.dbo.F_GET_MAP(2017, DEFAULT);
 
-
+-- Example of using the function to retrieve records for the student with personID 10 for the 2016-2017 school year
+SELECT *
+FROM FCPS_BB.dbo.F_GET_MAP(2017, 10);


### PR DESCRIPTION
This pull request will fix the bug identified in issue #7 .  Months in the second half of the academic year are now handled correctly by the function.

```SQL
SELECT *
FROM dbo.F_ELTMONTHS(2, 2017);
```

Now returns:

dtype | sdate | edate 
----- | ------ | ------
1 | 2016-07-01 | 2017-02-28
2 | 2017-02-01 | 2017-02-28
3 | 2016-02-01 | 2016-02-29
